### PR TITLE
chore: bump version to 15.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-csv</artifactId>
 	<packaging>jar</packaging>
 	<name>CSV Data Store</name>
-	<version>15.3.1-SNAPSHOT</version>
+	<version>15.4.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-csv.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-csv.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.3.0</version>
+		<version>15.4.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

Update the project version to 15.4.0-SNAPSHOT to align with the upcoming Fess 15.4.0 release.

## Changes Made

- Update project version from `15.3.1-SNAPSHOT` to `15.4.0-SNAPSHOT`
- Update parent `fess-parent` version from `15.3.0` to `15.4.0`

## Testing

- Build verification: `mvn clean compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)