### PR TITLE
Bump parent version to 15.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.5.0-SNAPSHOT</version>
+		<version>15.5.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
Update the parent POM version from `15.5.0-SNAPSHOT` to `15.5.0` for the release.

## Changes Made
- Updated `fess-parent` version in `pom.xml` from `15.5.0-SNAPSHOT` to `15.5.0`

## Testing
- No functional code changes; version bump only

## Breaking Changes
- None

## Additional Notes
- This prepares the project for the 15.5.0 release by pointing to the released parent POM